### PR TITLE
Build and push latest multiarch images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-CONTAINER_TOOL ?= podman
 TAG ?= latest
 CATALOG_IMG = quay.io/stolostron-grc/grc-mock-operators-catalog:$(TAG)
 MANIFEST = grc-mock-operators-catalog-$(TAG)
@@ -30,7 +29,7 @@ endif
 .PHONY: catalog-build-push
 catalog-build-push: opm
 	$(OPM) validate ./catalog
-	-$(CONTAINER_TOOL) manifest rm $(MANIFEST)
-	$(CONTAINER_TOOL) manifest create $(MANIFEST)
-	$(CONTAINER_TOOL) build -f catalog.Dockerfile --manifest $(MANIFEST) --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
-	$(CONTAINER_TOOL) manifest push $(MANIFEST) $(CATALOG_IMG)
+	-podman manifest rm $(MANIFEST)
+	podman manifest create $(MANIFEST)
+	podman build -f catalog.Dockerfile --manifest $(MANIFEST) --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+	podman manifest push $(MANIFEST) $(CATALOG_IMG)

--- a/build/build-push-bundles.sh
+++ b/build/build-push-bundles.sh
@@ -5,16 +5,23 @@ set -e
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
 
 for dirpath in $(find ${BASE_DIR}/operators -type d -print -mindepth 1 -maxdepth 1)
+do
+    cd "$dirpath"
+    operator_name=$(basename ${dirpath})
+    echo "* Handling operator ${operator_name} ..."
+    
+    podman manifest rm "${operator_name}" || true
+    podman manifest create "${operator_name}"
+    build_img="quay.io/stolostron-grc/${operator_name}:latest"
+    for arch in amd64 arm64 s390x ppc64le
     do
-        cd "$dirpath"
-        operator_name=$(basename ${dirpath})
-        echo "* Handling operator ${operator_name} ..."
-        build_img="quay.io/stolostron-grc/${operator_name}:latest"
-        podman build --platform linux/amd64 -f Dockerfile -t ${build_img}
-        podman push ${build_img}
-
-        bundle_img="quay.io/stolostron-grc/${operator_name}-bundle:latest"
-        make bundle IMG=$build_img
-        podman build --platform linux/amd64 -f bundle.Dockerfile  -t ${bundle_img}
-        podman push ${bundle_img}
+        podman build -f Dockerfile --manifest "${operator_name}" \
+          --platform "linux/${arch}" --build-arg "TARGETARCH=${arch}"
     done
+    podman manifest push "${operator_name}" "${build_img}"
+
+    bundle_img="quay.io/stolostron-grc/${operator_name}-bundle:latest"
+    make bundle IMG=$build_img
+    podman build --platform linux/amd64 -f bundle.Dockerfile  -t ${bundle_img}
+    podman push ${bundle_img}
+done

--- a/operators/dep-bundle-operator/bundle/manifests/dep-bundle-operator.clusterserviceversion.yaml
+++ b/operators/dep-bundle-operator/bundle/manifests/dep-bundle-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-03-28T18:17:10Z"
+    createdAt: "2025-04-22T17:25:12Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: dep-bundle-operator.v0.0.1

--- a/operators/dep-channel-operator/bundle/manifests/dep-channel-operator.clusterserviceversion.yaml
+++ b/operators/dep-channel-operator/bundle/manifests/dep-channel-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-03-28T18:17:23Z"
+    createdAt: "2025-04-22T17:25:20Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: dep-channel-operator.v0.0.1

--- a/operators/deprecation-operator/bundle/manifests/deprecation-operator.clusterserviceversion.yaml
+++ b/operators/deprecation-operator/bundle/manifests/deprecation-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-03-28T18:16:55Z"
+    createdAt: "2025-04-22T17:25:30Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: deprecation-operator.v0.0.1

--- a/operators/example-operator/bundle/manifests/example-operator.clusterserviceversion.yaml
+++ b/operators/example-operator/bundle/manifests/example-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-03-28T18:17:39Z"
+    createdAt: "2025-04-22T17:25:40Z"
     operators.operatorframework.io/builder: operator-sdk-v1.39.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: example-operator.v0.0.3


### PR DESCRIPTION
The bundles do not need to be multiarch, and the catalog already was multiarch.

Since the method to build multiarch images is different between docker and podman, this repository now requires the use of podman, for simplicity.