### PR TITLE
Fix image build in github actions

### DIFF
--- a/.github/workflows/push_bundles_catalog.yaml
+++ b/.github/workflows/push_bundles_catalog.yaml
@@ -1,5 +1,8 @@
 name: Build and release images
 
+env:
+  CONTAINER_TOOL: 'docker'
+
 on:
   push:
     branches:
@@ -18,6 +21,9 @@ jobs:
           registry: quay.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Build and Tag Operators bundle
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-TAG ?= latest
-CATALOG_IMG = quay.io/stolostron-grc/grc-mock-operators-catalog:$(TAG)
-MANIFEST = grc-mock-operators-catalog-$(TAG)
+CONTAINER_TOOL ?= podman
 
 LOCALBIN ?= $(PWD)/bin
 $(LOCALBIN):
@@ -29,7 +27,4 @@ endif
 .PHONY: catalog-build-push
 catalog-build-push: opm
 	$(OPM) validate ./catalog
-	-podman manifest rm $(MANIFEST)
-	podman manifest create $(MANIFEST)
-	podman build -f catalog.Dockerfile --manifest $(MANIFEST) --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
-	podman manifest push $(MANIFEST) $(CATALOG_IMG)
+	./build/build-push-catalog.sh

--- a/build/build-push-bundles.sh
+++ b/build/build-push-bundles.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
-set -e
+set -ex
+
+CONTAINER_TOOL="${CONTAINER_TOOL:-podman}"
 
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
+
+if [[ "${CONTAINER_TOOL}" == "podman" ]]; then
+    host_platform="$(podman info --format '{{.Version.OsArch}}')"
+else
+    host_platform="$(docker info --format '{{.ClientInfo.Os}}/{{.ClientInfo.Arch}}')"
+fi
 
 for dirpath in $(find ${BASE_DIR}/operators -type d -print -mindepth 1 -maxdepth 1)
 do
@@ -10,18 +18,32 @@ do
     operator_name=$(basename ${dirpath})
     echo "* Handling operator ${operator_name} ..."
     
-    podman manifest rm "${operator_name}" || true
-    podman manifest create "${operator_name}"
     build_img="quay.io/stolostron-grc/${operator_name}:latest"
     for arch in amd64 arm64 s390x ppc64le
     do
-        podman build -f Dockerfile --manifest "${operator_name}" \
-          --platform "linux/${arch}" --build-arg "TARGETARCH=${arch}"
+        echo "::group::Building ${operator_name} for ${arch}"
+        ${CONTAINER_TOOL} build -f Dockerfile -t "${build_img}-${arch}" \
+          --platform "linux/${arch}" --build-arg "TARGETARCH=${arch}" \
+          --build-arg "HOSTPLATFORM=${host_platform}" .
+        ${CONTAINER_TOOL} push "${build_img}-${arch}"
+        echo "::endgroup::"
     done
-    podman manifest push "${operator_name}" "${build_img}"
+
+    echo "::group::Building multiarch image and bundle for ${operator_name}"
+    ${CONTAINER_TOOL} manifest rm "${build_img}" || true
+    ${CONTAINER_TOOL} manifest create "${build_img}" "${build_img}-amd64" \
+      "${build_img}-arm64" "${build_img}-s390x" "${build_img}-ppc64le"
+
+    if [[ "${CONTAINER_TOOL}" == "podman" ]]; then
+        podman manifest push "${build_img}" "${build_img}"
+    else
+        docker manifest push "${build_img}"
+    fi
 
     bundle_img="quay.io/stolostron-grc/${operator_name}-bundle:latest"
-    make bundle IMG=$build_img
-    podman build --platform linux/amd64 -f bundle.Dockerfile  -t ${bundle_img}
-    podman push ${bundle_img}
+    make bundle "IMG=${build_img}"
+    ${CONTAINER_TOOL} build -f bundle.Dockerfile -t ${bundle_img} .
+    ${CONTAINER_TOOL} push ${bundle_img}
+
+    echo "::endgroup::"
 done

--- a/build/build-push-catalog.sh
+++ b/build/build-push-catalog.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -ex
+
+CONTAINER_TOOL="${CONTAINER_TOOL:-podman}"
+
+CATALOG_IMG="${CATALOG_IMG:-quay.io/stolostron-grc/grc-mock-operators-catalog}"
+CATALOG_TAG="${CATALOG_TAG:-latest}"
+
+manifest="${CATALOG_IMG}:${CATALOG_TAG}"
+
+for arch in amd64 arm64 s390x ppc64le
+do
+    echo "::group::Building catalog image for ${arch}"
+    ${CONTAINER_TOOL} build -f catalog.Dockerfile -t "${manifest}-${arch}" \
+      --platform "linux/${arch}" .
+    ${CONTAINER_TOOL} push "${manifest}-${arch}" 
+    echo "::endgroup::"
+done
+
+echo "::group::Building multiarch manifest for catalog"
+${CONTAINER_TOOL} manifest rm "${manifest}" || true
+${CONTAINER_TOOL} manifest create "${manifest}" "${manifest}-amd64" \
+  "${manifest}-arm64" "${manifest}-s390x" "${manifest}-ppc64le"
+
+if [[ "${CONTAINER_TOOL}" == "podman" ]]; then
+    podman manifest push "${manifest}" "${manifest}"
+else
+    docker manifest push "${manifest}"
+fi
+echo "::endgroup::"

--- a/operators/dep-bundle-operator/Dockerfile
+++ b/operators/dep-bundle-operator/Dockerfile
@@ -1,7 +1,13 @@
+# Utilities for emulation (like qemu static binaries) may be required for multiarch
+# builds. When not building on and for linux/amd64 (eg on Apple Silicon), the build
+# args should be set specially for the best results. That should be handled by the
+# `build-push-bundles.sh` script or Makefile.
+ARG HOSTPLATFORM=linux/amd64
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
 # Build the manager binary
-FROM golang:1.22 AS builder
-ARG TARGETOS
-ARG TARGETARCH
+FROM --platform=${HOSTPLATFORM} golang:1.22 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -16,16 +22,14 @@ COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/controller/ internal/controller/
 
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${TARGETOS}/${TARGETARCH} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/operators/dep-bundle-operator/Makefile
+++ b/operators/dep-bundle-operator/Makefile
@@ -61,6 +61,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+HOST_GOOS=$(shell go env GOOS)
+HOST_GOARCH=$(shell go env GOARCH)
+
 # CONTAINER_TOOL defines the container tool to be used for building images.
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
@@ -142,7 +145,8 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	$(CONTAINER_TOOL) build --build-arg "HOSTPLATFORM=$(HOST_GOOS)/$(HOST_GOARCH)" \
+	  --build-arg "TARGETARCH=$(HOST_GOARCH)" --build-arg "TARGETOS=$(HOST_GOOS)" -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -258,7 +262,7 @@ ifeq (, $(shell which operator-sdk 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	OS=$(HOST_GOOS) && ARCH=$(HOST_GOARCH) && \
 	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OPERATOR_SDK) ;\
 	}
@@ -290,7 +294,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	OS=$(HOST_GOOS) && ARCH=$(HOST_GOARCH) && \
 	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}

--- a/operators/dep-channel-operator/Dockerfile
+++ b/operators/dep-channel-operator/Dockerfile
@@ -1,7 +1,13 @@
+# Utilities for emulation (like qemu static binaries) may be required for multiarch
+# builds. When not building on and for linux/amd64 (eg on Apple Silicon), the build
+# args should be set specially for the best results. That should be handled by the
+# `build-push-bundles.sh` script or Makefile.
+ARG HOSTPLATFORM=linux/amd64
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
 # Build the manager binary
-FROM golang:1.22 AS builder
-ARG TARGETOS
-ARG TARGETARCH
+FROM --platform=${HOSTPLATFORM} golang:1.22 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -16,16 +22,14 @@ COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/controller/ internal/controller/
 
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${TARGETOS}/${TARGETARCH} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/operators/dep-channel-operator/Makefile
+++ b/operators/dep-channel-operator/Makefile
@@ -61,6 +61,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+HOST_GOOS=$(shell go env GOOS)
+HOST_GOARCH=$(shell go env GOARCH)
+
 # CONTAINER_TOOL defines the container tool to be used for building images.
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
@@ -142,7 +145,8 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	$(CONTAINER_TOOL) build --build-arg "HOSTPLATFORM=$(HOST_GOOS)/$(HOST_GOARCH)" \
+	  --build-arg "TARGETARCH=$(HOST_GOARCH)" --build-arg "TARGETOS=$(HOST_GOOS)" -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -258,7 +262,7 @@ ifeq (, $(shell which operator-sdk 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	OS=$(HOST_GOOS) && ARCH=$(HOST_GOARCH) && \
 	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OPERATOR_SDK) ;\
 	}
@@ -290,7 +294,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	OS=$(HOST_GOOS) && ARCH=$(HOST_GOARCH) && \
 	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}

--- a/operators/deprecation-operator/Dockerfile
+++ b/operators/deprecation-operator/Dockerfile
@@ -1,7 +1,13 @@
+# Utilities for emulation (like qemu static binaries) may be required for multiarch
+# builds. When not building on and for linux/amd64 (eg on Apple Silicon), the build
+# args should be set specially for the best results. That should be handled by the
+# `build-push-bundles.sh` script or Makefile.
+ARG HOSTPLATFORM=linux/amd64
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
 # Build the manager binary
-FROM golang:1.22 AS builder
-ARG TARGETOS
-ARG TARGETARCH
+FROM --platform=${HOSTPLATFORM} golang:1.22 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -16,16 +22,14 @@ COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/controller/ internal/controller/
 
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${TARGETOS}/${TARGETARCH} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/operators/deprecation-operator/Makefile
+++ b/operators/deprecation-operator/Makefile
@@ -61,6 +61,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+HOST_GOOS=$(shell go env GOOS)
+HOST_GOARCH=$(shell go env GOARCH)
+
 # CONTAINER_TOOL defines the container tool to be used for building images.
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
@@ -142,7 +145,8 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	$(CONTAINER_TOOL) build --build-arg "HOSTPLATFORM=$(HOST_GOOS)/$(HOST_GOARCH)" \
+	  --build-arg "TARGETARCH=$(HOST_GOARCH)" --build-arg "TARGETOS=$(HOST_GOOS)" -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -258,7 +262,7 @@ ifeq (, $(shell which operator-sdk 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	OS=$(HOST_GOOS) && ARCH=$(HOST_GOARCH) && \
 	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OPERATOR_SDK) ;\
 	}
@@ -290,7 +294,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	OS=$(HOST_GOOS) && ARCH=$(HOST_GOARCH) && \
 	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}

--- a/operators/example-operator/Dockerfile
+++ b/operators/example-operator/Dockerfile
@@ -1,7 +1,13 @@
+# Utilities for emulation (like qemu static binaries) may be required for multiarch
+# builds. When not building on and for linux/amd64 (eg on Apple Silicon), the build
+# args should be set specially for the best results. That should be handled by the
+# `build-push-bundles.sh` script or Makefile.
+ARG HOSTPLATFORM=linux/amd64
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
 # Build the manager binary
-FROM golang:1.22 AS builder
-ARG TARGETOS
-ARG TARGETARCH
+FROM --platform=${HOSTPLATFORM} golang:1.22 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -16,16 +22,14 @@ COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/controller/ internal/controller/
 
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${TARGETOS}/${TARGETARCH} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/operators/example-operator/Makefile
+++ b/operators/example-operator/Makefile
@@ -60,6 +60,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+HOST_GOOS=$(shell go env GOOS)
+HOST_GOARCH=$(shell go env GOARCH)
+
 # CONTAINER_TOOL defines the container tool to be used for building images.
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
@@ -141,7 +144,8 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_TOOL) build -t ${IMG} .
+	$(CONTAINER_TOOL) build --build-arg "HOSTPLATFORM=$(HOST_GOOS)/$(HOST_GOARCH)" \
+	  --build-arg "TARGETARCH=$(HOST_GOARCH)" --build-arg "TARGETOS=$(HOST_GOOS)" -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -257,7 +261,7 @@ ifeq (, $(shell which operator-sdk 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	OS=$(HOST_GOOS) && ARCH=$(HOST_GOARCH) && \
 	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OPERATOR_SDK) ;\
 	}
@@ -289,7 +293,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	OS=$(HOST_GOOS) && ARCH=$(HOST_GOARCH) && \
 	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
@@ -315,7 +319,7 @@ endif
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool $(CONTAINER_TOOL) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push


### PR DESCRIPTION
The updated Dockerfiles use go's ability to cross-compile in order to speed up the multi-arch builds - no emulation is needed on the build system, and the local image cache can be used for all steps before the build. However, they require some additional build args, which the scripts and Makefiles now provide.

However, these container builds require a newer version of podman than is currently available on the GitHub Actions runners, to honor the `--platform` flag inside the `FROM` instructions. So, the workflow now uses docker there, which required many changes to the multi-arch build scripts. The method is, regrettably, much more in the docker style now, but it will still work with podman.

For reference, the builds require buildah v1.37.0, which is in podman v5.1.0; github actions currently has podman v4.9.3.